### PR TITLE
Fix a time parse issue

### DIFF
--- a/persist.go
+++ b/persist.go
@@ -2,7 +2,6 @@ package persist
 
 import (
 	"bytes"
-	"log"
 	"time"
 
 	"github.com/boltdb/bolt"
@@ -62,7 +61,6 @@ func (c *cache) Get(i *ndn.Interest) (match *ndn.Data) {
 				continue
 			}
 			t := time.Unix(int64(ent.Time), 0)
-			log.Print(t)
 			if !i.Selectors.Match(string(k), ent.Data, t) {
 				continue
 			}


### PR DESCRIPTION
go-ndn/tlv can't parse time.Time type, but go-ndn/persist use time.Time type to store data time. 
It will cause time calculate problem.So I fixed it using uint64 instead of time.Time.Now it can work well and can get fresh data.
